### PR TITLE
Fixing Languages MVT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+MVT/AppMVT/__pycache__/
+MVT/MVT/__pycache__/
+*.pyc

--- a/MVT/AppMVT/forms.py
+++ b/MVT/AppMVT/forms.py
@@ -10,3 +10,6 @@ class ContactForm(forms.Form):
 class LanguagesForm(forms.Form):
      language=forms.CharField(label='Lenguaje', widget=forms.TextInput(attrs={'placeholder': 'Ingrese su nombre completo', 'class': 'form-control', 'style': 'width: 246px;'}))
      text=forms.CharField(label='Descripción', max_length = 600, widget=forms.Textarea(attrs={'placeholder': 'Ingrese una descripción del lenguaje', 'class': 'form-control', 'style': 'width: 246px;'}))
+
+class SearchLanguageForm(forms.Form):
+     language=forms.CharField(widget=forms.TextInput(attrs={'placeholder': 'Nombre del lenguaje', 'class': 'form-control text-center', 'style': 'width: 246px;'}))

--- a/MVT/AppMVT/models.py
+++ b/MVT/AppMVT/models.py
@@ -6,7 +6,12 @@ class Contact(models.Model):
     phone=models.IntegerField()
     message=models.CharField(max_length=400)
 
+    def __unicode__(self):
+        return self.full_name
     
 class Languages(models.Model):
      language=models.CharField(max_length=50)
      text=models.CharField(max_length=600)
+
+     def __unicode__(self):
+        return self.language

--- a/MVT/AppMVT/templates/AppMVT/languages.html
+++ b/MVT/AppMVT/templates/AppMVT/languages.html
@@ -1,26 +1,48 @@
-{% extends "AppMVT/maintemplate.html" %}
-{% load static %}
-{% block Title %}
+{% extends "AppMVT/maintemplate.html" %} {% load static %} {% block Title %}
 <title>Lenguajes</title>
-{% endblock %}
-{% block Masterhead %}
-<div style="margin: 8em";></div>
-{% endblock %}
-{% block contenidoQueCambia %}
+{% endblock %} {% block Masterhead %}
+<div style="margin: 8em" ;></div>
+{% endblock %} {% block contenidoQueCambia %}
 <section id="language">
-    <div class="container"; style="margin:5em;">
-        <h2 class="page-section-heading text-center text-uppercase text-secondary mb-0">Lenguajes de Programación</h2>
-        <div style="margin: 2em";></div>
-        <h4 class="page-section-heading text-center text-secondary mb-0">Busque un lenguaje y descubra más acerca de el</h4>
-        <div class="divider-custom">
-            <div class="divider-custom-line"></div>
-            <div class="divider-custom-icon"><i class="fas fa-star"></i></div>
-            <div class="divider-custom-line"></div>
-        </div>
+  <div class="container" ; style="margin: 5em">
+    <h2
+      class="page-section-heading text-center text-uppercase text-secondary mb-0"
+    >
+      Lenguajes de Programación
+    </h2>
+    <div style="margin: 2em" ;></div>
+    <h4 class="page-section-heading text-center text-secondary mb-0">
+      Busque un lenguaje y descubra más acerca de el
+    </h4>
+    <div class="divider-custom">
+      <div class="divider-custom-line"></div>
+      <div class="divider-custom-icon"><i class="fas fa-star"></i></div>
+      <div class="divider-custom-line"></div>
     </div>
-    <form action="{% url 'AppMVT/lenguajes' %}" method="GET"style="margin: 0 auto; width: fit-content">
-            <p style="text-align:center; font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;">Lenguaje:<input type="text" name="language" id="language"></p>
-            <p style="text-align: center;"><input class="btn btn-primary" type="submit" value="Buscar"></p>
-    </form>
-</section>  
+  </div>
+  {% if language %}
+  <div>
+    <p>{{ language }}</p>
+    <p>{{ text.text }}</p>
+  </div>
+  {% endif %}
+  <form
+    action="/AppMVT/buscarlenguajes"
+    method="GET"
+    style="margin: 0 auto; width: fit-content"
+  >
+    <p
+      style="
+        text-align: center;
+        font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande',
+          'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+      "
+    >
+      Lenguaje:<input type="text" name="language" id="language" />
+    </p>
+    <p style="text-align: center">
+      <input class="btn btn-primary" type="submit" value="Buscar" />
+    </p>
+  </form>
+</section>
 {% endblock %}

--- a/MVT/AppMVT/templates/AppMVT/languages.html
+++ b/MVT/AppMVT/templates/AppMVT/languages.html
@@ -23,9 +23,9 @@
   {% if language %}
   <div>
     <p>{{ language }}</p>
-    <p>{{ text.text }}</p>
+    <p>{{ text }}</p>
   </div>
-  {% endif %}
+  {% else %}
   <form
     action="/AppMVT/buscarlenguajes"
     method="GET"
@@ -44,5 +44,6 @@
       <input class="btn btn-primary" type="submit" value="Buscar" />
     </p>
   </form>
+  {% endif %}
 </section>
 {% endblock %}

--- a/MVT/AppMVT/templates/AppMVT/languages.html
+++ b/MVT/AppMVT/templates/AppMVT/languages.html
@@ -1,35 +1,35 @@
 {% extends "AppMVT/maintemplate.html" %} {% load static %} {% block Title %}
 <title>Lenguajes</title>
 {% endblock %} {% block Masterhead %}
-<div style="margin: 8em" ;></div>
+<div style="margin: 8em"></div>
 {% endblock %} {% block contenidoQueCambia %}
-<section id="language">
-  <div class="container" ; style="margin: 5em">
+<section class="page-section portfolio" style="margin: 0 auto" id="language">
+  <div class="container" ; style="margin: 5em auto">
     <h2
       class="page-section-heading text-center text-uppercase text-secondary mb-0"
     >
       Lenguajes de Programación
     </h2>
     <div style="margin: 2em" ;></div>
-    <h4 class="page-section-heading text-center text-secondary mb-0">
-      Busque un lenguaje y descubra más acerca de el
-    </h4>
     <div class="divider-custom">
       <div class="divider-custom-line"></div>
       <div class="divider-custom-icon"><i class="fas fa-star"></i></div>
       <div class="divider-custom-line"></div>
     </div>
+    <h4 class="page-section-heading text-center text-secondary mb-0">
+      Busque un lenguaje y descubra más acerca de el
+    </h4>
   </div>
   {% if language %}
-  <div>
-    <p>{{ language }}</p>
+  <div class="portfolio-item mx-auto">
+    <p class="text-center">{{ language }}</p>
     <p>{{ text }}</p>
   </div>
-  {% else %}
+  {% endif %}
   <form
     action="/AppMVT/buscarlenguajes"
     method="GET"
-    style="margin: 0 auto; width: fit-content"
+    style="margin: 2em auto 0 auto; width: fit-content"
   >
     <p
       style="
@@ -38,12 +38,18 @@
           'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
       "
     >
-      Lenguaje:<input type="text" name="language" id="language" />
+      <label for="language">
+        <input
+          class="form-control text-center"
+          placeholder="Nombre del lenguaje"
+          type="text"
+          name="language"
+          id="language"
+      /></label>
     </p>
     <p style="text-align: center">
       <input class="btn btn-primary" type="submit" value="Buscar" />
     </p>
   </form>
-  {% endif %}
 </section>
 {% endblock %}

--- a/MVT/AppMVT/urls.py
+++ b/MVT/AppMVT/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path('', inicioApp, name='inicioApp'),
     path('inicioApp/', inicioApp),
     path('lenguajes/', languages, name='languages'),
+    path('lenguajes/<language>', languages, name='languages'),
     path('buscarlenguajes/', searchlanguages, name='searchlanguages'),
     path('about/', about, name='about'),
     path('contacto/', contactform, name='contactform'),

--- a/MVT/AppMVT/views.py
+++ b/MVT/AppMVT/views.py
@@ -13,11 +13,11 @@ def about(request):
 
 def languages(request, language=False):
     if language:
-        text = Languages.objects.filter(language=language)
+        lang = Languages.objects.get(language__icontains=language)
         return render(
             request,
             'AppMVT/languages.html',
-            {'language': language, 'text': text}
+            {'language': lang.language, 'text': lang.text}
         )
     else:
         return render(request,'AppMVT/languages.html')

--- a/MVT/AppMVT/views.py
+++ b/MVT/AppMVT/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from AppMVT.forms import ContactForm, LanguagesForm
 from AppMVT.models import Contact, Languages
 from django.http import HttpResponse, HttpResponseRedirect
@@ -11,14 +11,22 @@ def inicioApp(request):
 def about(request):
     return render(request, 'AppMVT/about.html')
 
-def languages(request):
-    return render(request, 'AppMVT/languages.html')
+def languages(request, language=False):
+    if language:
+        text = Languages.objects.filter(language=language)
+        return render(
+            request,
+            'AppMVT/languages.html',
+            {'language': language, 'text': text}
+        )
+    else:
+        return render(request,'AppMVT/languages.html')
 
 def searchlanguages(request):
     if request.GET["language"]:
         language=request.GET["language"]
-        text=Languages.objects.filter(language_icontains=language)
-        return render(request, 'AppMVT/languages.html', {"language":language,"text":text})
+        # text=Languages.objects.filter(language=language)
+        return redirect(languages, language=language)
     else:
         respuesta="No enviaste datos"
 

--- a/MVT/MVT/settings.py
+++ b/MVT/MVT/settings.py
@@ -55,7 +55,7 @@ ROOT_URLCONF = 'MVT.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['C:/Users/marjo/OneDrive/Área de Trabalho/MVT/MVT/MVT/templates', 'C:/Users/marjo/OneDrive/Área de Trabalho/MVT/MVT/AppMVT/templates/'],
+        'DIRS': ['./MVT/templates', './AppMVT/templates/'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -118,8 +118,8 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 STATICFILES_DIRS = [
-    BASE_DIR / "C:/Users/marjo/OneDrive/Área de Trabalho/MVT/MVT/MVT/static",
-    "C:/Users/marjo/OneDrive/Área de Trabalho/MVT/MVT/AppMVT/static",
+    BASE_DIR / "./MVT/static",
+    "./AppMVT/static",
 ]
 
 # Default primary key field type


### PR DESCRIPTION
Mexi no **urls.py**, pra reconhecer urls do tipo _/lenguajes/python_, que serão redirecionadas para a **view** _languages()_, onde será feita a consulta na base de dados para exibir no template _languages.html_ .

A **view** _searchlanguages()_ também foi alterada para apenas ler o campo do formulário e repassar esse valor como uma varíavel para a view _languages()_ via a url _/lenguajes/\<language\>_. A view _searchlanguages()_ não está renderizando nenhum template, agora ela apenas faz o _redirect_ para _/lenguajes/\<language\>_, onde será realmente feito a consulta na base de dados de linguagens.

Alterei o **template** _languages.html_ para exibir, quando houver, o nome da linguagem buscada. Ainda estou tentando descobrir como ler o valor de _text_, que contem o resultado do _filter()_ feito no model **Language**.

Criei o arquivo **.gitignore** com as pastas e arquivos que serão ignoradas pelo git, pois não precisam ser versionadas.